### PR TITLE
Add package management commands to mirror server

### DIFF
--- a/hosting/mirror-server/src/cli/commands/__init__.py
+++ b/hosting/mirror-server/src/cli/commands/__init__.py
@@ -10,3 +10,5 @@ from .gh import gh_command
 from .gl import gl_command
 from .gpkl import gpkl_command
 from .gpkm import gpkm_command
+from .add_pkg import add_pkg_command
+from .new_pkg import new_pkg_command

--- a/hosting/mirror-server/src/cli/commands/add_pkg.py
+++ b/hosting/mirror-server/src/cli/commands/add_pkg.py
@@ -1,0 +1,16 @@
+from ...network.message_json import JSONMessage
+from json import load
+from base64 import b64encode
+
+def add_pkg_command(cli, /, session_id, package_data, package_archive):
+    with open(package_data, 'r') as fp:
+        data = load(fp)
+    with open(package_archive, 'rb') as fp:
+        cli.client.write(JSONMessage({"action": "add_package", "data": {"session_id": session_id, "package_data": data, "package_archive": b64encode(fp.read()).decode("utf-8")}}))
+    try:
+        response = cli.client.read()
+    except ConnectionError:
+        print("server connection close without giving a response.")
+        cli.close()
+        return
+    print(JSONMessage.from_message(response).content["data"]["msg"])

--- a/hosting/mirror-server/src/cli/commands/new_pkg.py
+++ b/hosting/mirror-server/src/cli/commands/new_pkg.py
@@ -1,0 +1,14 @@
+from ..network_command_wrapper import network_command, default_json_payload_filler
+from ..middlewares.check_response import check_response
+from ..middlewares.check_status import check_status
+from ...network.message_json import JSONMessage
+
+@network_command(
+    JSONMessage({
+        "action": "new_package",
+        "data": {"session_id": "$session_id", "package_name": "$package_name"}
+    }), default_json_payload_filler,
+    [check_response, check_status]
+)
+def new_pkg_command(cli, /, session_id, package_name, response):
+    print(response.content["data"]["msg"])

--- a/hosting/mirror-server/src/package/mirror_server.py
+++ b/hosting/mirror-server/src/package/mirror_server.py
@@ -75,10 +75,10 @@ class MirrorServer(object):
     def load(self):
         if (not self.location):
             return
-        
-        self.checksum: str = hash_file(join(self.location, "pkgs.list"))
 
         if (isfile(join(self.location, "pkgs.list"))):
+            self.checksum: str = hash_file(join(self.location, "pkgs.list"))
+
             with open(join(self.location, "pkgs.list"), 'r') as fp:
                 line = fp.readline()
                 while line:
@@ -87,7 +87,8 @@ class MirrorServer(object):
                     self.packages[name] = Package(name, location, version, sha256, load=self.recursive_load, recursive_load=self.recursive_load, base_path=self.location)
 
                     line = fp.readline()
-
+        else:
+            self.checksum = "0"
         self.loaded = True
 
     def add_package_register(self, name) -> Package:

--- a/hosting/mirror-server/src/package/package.py
+++ b/hosting/mirror-server/src/package/package.py
@@ -98,7 +98,7 @@ class Package(object):
             print("file not found, remember, remote package is not implemented.")
             return
         
-        arch = package_metadata.get("arch", "x64")
+        arch = package_metadata.get("architecture", "x64")
         version = package_metadata.get("version", "1.0.0")
         machine = package_metadata.get("machine", "Gen-Linux")
         description = package_metadata.get("description", f"{self.name} package.")
@@ -112,7 +112,7 @@ class Package(object):
             arch,
             version,
             machine,
-            '/' + relpath(json_path, self.base_path).replace('\\', '/').lstrip('/')
+            '/' + relpath(json_path, self.base_path).replace('\\', '/').lstrip('/'), base_path=self.base_path
         )
         self.listing[package_hash].package_data = {
             "package": self.name,

--- a/hosting/mirror-server/wcrmgr.py
+++ b/hosting/mirror-server/wcrmgr.py
@@ -3,6 +3,7 @@
 from sys import exit, argv
 from string import hexdigits
 
+from os.path import isfile
 from src import *
 from src.cli.commands import *
 from src.cli.middlewares import *
@@ -145,6 +146,25 @@ def main():
         write_command,
         [
             CLICommandArg("session_id", CLICommandArg.ARG_MANDATORY, argument_parser=int, argument_checker=lambda x: x.isnumeric())
+        ]
+    ), True)
+
+    nc.add_command(CLICommand(
+        "new_pkg",
+        new_pkg_command,
+        [
+            CLICommandArg("session_id", CLICommandArg.ARG_MANDATORY, argument_parser=int, argument_checker=lambda x: x.isnumeric()),
+            CLICommandArg("package_name", CLICommandArg.ARG_MANDATORY)
+        ]
+    ), True)
+
+    nc.add_command(CLICommand(
+        "add_pkg",
+        add_pkg_command,
+        [
+            CLICommandArg("session_id", CLICommandArg.ARG_MANDATORY, argument_parser=int, argument_checker=lambda x: x.isnumeric()),
+            CLICommandArg("package_data", CLICommandArg.ARG_MANDATORY, argument_checker=lambda x: isfile(x)),
+            CLICommandArg("package_archive", CLICommandArg.ARG_MANDATORY, argument_checker=lambda x: isfile(x))
         ]
     ), True)
 

--- a/hosting/mirror-server/wcrmirror.py
+++ b/hosting/mirror-server/wcrmirror.py
@@ -2,16 +2,18 @@
 
 from sys import exit
 from sys import argv
-from os import environ
+from os import environ, mkdir
+from os.path import join, isdir
 from src import *
 from src.arghandler import *
 from dotenv import load_dotenv, find_dotenv
 from json import dumps
 from hashlib import sha256
+from base64 import b64decode
 
 import sys
 
-load_dotenv(find_dotenv())
+load_dotenv(find_dotenv(usecwd=True))
 
 FLAG_ADMIN = (1 << 0)
 FLAG_USER = (1 << 1)
@@ -371,6 +373,71 @@ def route_write(client: Client, server: Server, message: JSONMessage, /, session
     }))
 
 @protected_route(FLAG_ADMIN)
+def route_new_pkg_listing(client: Client, server: Server, message: JSONMessage, /, session: Session = None):
+    if ("package_name" not in message.content["data"]):
+        client.write(JSONMessage({
+            "action": message.content["action"],
+            "data": {
+                "msg": "ko"
+            },
+            "code": 1
+        }))
+
+        return
+    
+    session.session_instance.add_package_register(message.content["data"]["package_name"])
+
+    client.write(JSONMessage({
+        "action": message.content["action"],
+        "data": {
+            "msg": "ok"
+        },
+        "code": 0
+    }))
+
+@protected_route(FLAG_ADMIN)
+def route_add_pkg(client: Client, server: Server, message: JSONMessage, /, session: Session = None):
+    if ("package_data" not in message.content["data"]):
+        client.write(JSONMessage({
+            "action": message.content["action"],
+            "data": {
+                "msg": "ko"
+            },
+            "code": 1
+        }))
+
+        return
+    
+    if ("package_archive" not in message.content["data"]):
+        client.write(JSONMessage({
+            "action": message.content["action"],
+            "data": {
+                "msg": "ko"
+            },
+            "code": 1
+        }))
+
+        return
+
+    new_package = session.session_instance.add_package_register(message.content["data"]["package_data"]["package"])
+    name = f"{message.content['data']['package_data']['package']}-{message.content['data']['package_data']['version']}-{message.content['data']['package_data']['architecture']}-{message.content['data']['package_data']['machine']}.tar.gz"
+
+    if (not isdir(join(session.session_instance.location, "temp"))):
+        mkdir(join(session.session_instance.location, "temp"))
+    with open(join(session.session_instance.location, "temp", name), 'wb+') as fp:
+        fp.write(b64decode(message.content["data"]["package_archive"]))
+
+    listing = new_package.add_package_listing(message.content["data"]["package_data"], join(session.session_instance.location, "temp", name))
+
+    client.write(JSONMessage({
+        "action": message.content["action"],
+        "data": {
+            "msg": "ok"
+        },
+        "code": 0
+    }))
+
+@protected_route(FLAG_ADMIN)
 def route_disconnect(client: Client, server: Server, message: JSONMessage, /, session: Session = None):
     session.close()
     del server.sessions[session.get_id()]
@@ -449,6 +516,8 @@ def main():
     R.add_route("get_listing", route_get_listing)
     R.add_route("get_package_listing", route_get_package_listing)
     R.add_route("get_package_metadata", route_get_package_metadata)
+    R.add_route("add_package", route_add_pkg)
+    R.add_route("new_package", route_new_pkg_listing)
     R.add_route("goodbye", route_goodbye)
 
     S.set_handler(WCRHandler(R))


### PR DESCRIPTION
## Description
Adds CLI and server-side support for registering and uploading packages to the mirror server.

Fixes #85 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- `mirror_server.py`: moved `hash_file()` inside the `isfile()` check to avoid crash when `pkgs.list` is absent; falls back to checksum `"0"`
- `package.py`: renamed metadata key `arch` → `architecture`; pass `base_path` to `add_package_listing`
- `add_pkg.py` / `new_pkg.py`: two new CLI commands for package management
- `wcrmgr.py`: registered the two new commands
- `wcrmirror.py`: added `new_package` and `add_package` admin routes; fixed `find_dotenv(usecwd=True)`

## Testing
- Manually tested `new_pkg` and `add_pkg` commands against a running mirror server instance
- Verified server responds with `"ok"` on valid input and `"ko"` on missing fields

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated CHANGELOG.md (if applicable)
